### PR TITLE
[brief] Changes 'typedef' to 'using'.

### DIFF
--- a/tutorials/04_matrices_exceptions/04_matrices_exceptions.org
+++ b/tutorials/04_matrices_exceptions/04_matrices_exceptions.org
@@ -31,7 +31,7 @@ Run cmake as usual to create the Visual Studio configuration files. See Part1 of
 The provided program for part 1 is called ~part1~, and contains a type ~matrix_type~ which is defined by the statement
 
 #+BEGIN_SRC C++ 
-typedef std::vector< std::vector< double > > matrix_type;
+using matrix_type = std::vector< std::vector< double > >;
 #+END_SRC
 
 The ~matrix_type~ is therefore a vector containing row vectors, with the contents of each row having type ~double~.

--- a/tutorials/04_matrices_exceptions/lab04/part1/part1.cpp
+++ b/tutorials/04_matrices_exceptions/lab04/part1/part1.cpp
@@ -7,9 +7,7 @@
 #include <vector>
 
 // Define a type Matrix which is a vector of vectors containing doubles.
-typedef std::vector<
-    std::vector<double>
-    > matrix_type;
+using matrix_type = std::vector< std::vector< double > >;
 
 /* Functions to complete */
 

--- a/tutorials/04_matrices_exceptions/lab04/part2/part2.cpp
+++ b/tutorials/04_matrices_exceptions/lab04/part2/part2.cpp
@@ -9,7 +9,7 @@
 #include <vector>
 
 // Define a type matrix_type which is a vector of vectors containing doubles.
-typedef std::vector< std::vector< double > > matrix_type;
+using matrix_type = std::vector< std::vector< double > >;
 
 /* Functions to complete (Exercise 2A) */
 


### PR DESCRIPTION
[detailed]
- typedef is a keyword that was inherited from C while 'using' was introduced in
  C++11. While they are functionally equivalent in general, 'using' allows for
  aliasing on templates, which is something that 'typedef' does not allow.