### PR TITLE
Fixing indentation in lab07 org

### DIFF
--- a/tutorials/07_inheritance/07_inheritance.org
+++ b/tutorials/07_inheritance/07_inheritance.org
@@ -88,15 +88,14 @@ Open ~shape.hpp~, the declaration for ~Shape~ is:
 #+BEGIN_SRC C++
 class Shape {
 public:
+	// Abstract methods
+	virtual double area() const = 0;
+	virtual double perimeter() const = 0;
+	virtual Point center() const = 0;
 
-  // Abstract methods
-  virtual double area() const = 0;
-  virtual double perimeter() const = 0;
-  virtual Point center() const = 0;
-
-  virtual std::string name() const {
-    return "Shape";
-  }
+	virtual std::string name() const {
+		return "Shape";
+	}
 };
 #+END_SRC
 
@@ -109,27 +108,27 @@ Open ~rectangle.hpp~
 #+BEGIN_SRC C++
 class Rectangle: public Shape {
 public:
-	  // Constructors
-    Rectangle(Point const & min, Point const & max);
-    Rectangle(double x, double y, double width, double height);
-	  /*
-     * inherited methods that we need to implement
-     * or reimplement
-     */
-    double area() const override;
-    double perimeter() const override;
-    Point center() const override;
-    std::string name() const override;
+	// Constructors
+	Rectangle(Point const & min, Point const & max);
+	Rectangle(double x, double y, double width, double height);
+	/*
+	* inherited methods that we need to implement
+	* or reimplement
+	*/
+	double area() const override;
+	double perimeter() const override;
+	Point center() const override;
+	std::string name() const override;
 
-    // Other methods
-    double width() const;
-	  double height() const;
-    Point getMin() const;
-    Point getMax() const;
+	// Other methods
+	double width() const;
+	double height() const;
+	Point getMin() const;
+	Point getMax() const;
 
 private:
-    Point mMin;
-    Point mMax;
+	Point mMin;
+	Point mMax;
 };
 #+END_SRC
 

--- a/tutorials/07_inheritance/lab07/part3/part3.cpp
+++ b/tutorials/07_inheritance/lab07/part3/part3.cpp
@@ -10,18 +10,22 @@
 #include "square.hpp"
 #include "point.hpp"
 
+std::string getName(Shape const & s) {
+  return s.name();
+}
+
 int main(int argc, char *argv[]) {
 
   Square square(Point(), 2);
 
-  std::cout << "square Class: " << square.name() << std::endl;
+  std::cout << "square Class: " << getName(square) << std::endl;
   std::cout << "square area: "  << square.area() << std::endl;
   std::cout << "square dimensions: "  << square.width() << " x " << square.height() << std::endl;
   std::cout << "square center: "  << square.center() << std::endl;
   std::cout << "square min/max: " << square.getMin() << " " << square.getMax() << std::endl;
 
   Square square1(Point(1, 2), 3);
-  std::cout << "Square1 Class: " << square1.name() << std::endl;
+  std::cout << "Square1 Class: " << getName(square1) << std::endl;
   std::cout << "square1 area: "  << square1.area() << std::endl;
   std::cout << "square1 dimensions: "  << square1.width() << " x " << square1.height() << std::endl;
   std::cout << "square1 center: " << square1.center() << std::endl;


### PR DESCRIPTION
Some of the indentation was weird in the code.
Adding back verifiable difference between virtual and non-virtual override.